### PR TITLE
Add JSDoc comments where applicable

### DIFF
--- a/Framework/Classes/Features/block.ts
+++ b/Framework/Classes/Features/block.ts
@@ -21,7 +21,7 @@ import { Molang, Permutation } from "../classes";
  * @param identifier The string that is used in-game to identify the block.
  * @param displayName Optional (but recommended), the string to show up as the display name of the block in-game.
  * @param language Optional, the language the display name originates from. Defaults to `en_US`.
- * ### Example
+ * @example
  * ```ts
  * new Block("peanut:example", "Example Block")
  * ```

--- a/Framework/Classes/Features/item.ts
+++ b/Framework/Classes/Features/item.ts
@@ -19,7 +19,7 @@ import { Molang } from "../classes";
  * @param identifier The string that is used in-game to identify the item.
  * @param displayName Optional (but recommended), the string to show up as the display name of the item in-game.
  * @param language Optional, the language the display name originates from. Defaults to `en_US`.
- * ### Example
+ * @example
  * ```ts
  * new Item("peanut:example", "Example Item")
  * ```
@@ -60,7 +60,7 @@ export class Item {
    * Block Placer item component. Items with this component will place a block when used.
    * @param block The block that will be placed.
    * @param useOn List of block descriptors that contain blocks that this item can be used on. If left empty, all blocks will be allowed.
-   * ### Example
+   * @example
    * ```ts
     new Item("peanut:rose_flower_basket", "Basket of Roses")
     .blockPlacer("minecraft:poppy", ["minecraft:grass_block", "minecraft:dirt"])

--- a/Framework/Classes/Properties/blockMap.ts
+++ b/Framework/Classes/Properties/blockMap.ts
@@ -4,15 +4,29 @@ import { Benchmark, Console } from "../../Utilities/utils";
 import { FORMAT_VERSION } from "../../version";
 
 /**
- * Block map class for generating block texture and sound mappings.
+ * BlockMap class used for generating block texture and sound mappings.
  *
- * Generates as `blocks.json`
+ * This class generates a JSON file (`blocks.json`) containing texture and sound mappings for blocks.
+ * Each block entry can specify textures for different sides, sound, and additional properties like isotropy.
  */
 export class BlockMap {
   private projectId = "unknown";
   private data: any = {
     format_version: FORMAT_VERSION.BLOCKMAP,
   };
+
+  /**
+   * Adds entries to the block map.
+   *
+   * This method allows adding mappings for blocks, where each block can have various properties such as textures,
+   * carried textures, sound, and isotropic settings. The textures can be specified for each block side or as a general texture.
+   *
+   * @param entries An object where each key is a block name, and the value is an object containing the block's properties:
+   *   - `textures`: A map of block side names to texture paths, or a single texture for all sides.
+   *   - `carried_textures`: The texture applied when the block is carried.
+   *   - `sound`: The sound played when the block is interacted with.
+   *   - `isotropic`: A boolean indicating if the texture should be applied isotropically (same on all sides).
+   */
   public entry(entries: {
     [key: string]: {
       textures?:
@@ -32,8 +46,17 @@ export class BlockMap {
       this.data[e[0]] = e[1];
     }
   }
+
+  /**
+   * Compiles and generates the `blocks.json` file.
+   *
+   * This method creates the `blocks.json` file in the specified resource pack directory, including the texture
+   * and sound mappings for all blocks added using the `entry` method.
+   *
+   * @param rePath The base path where the resource pack is located, used to determine where the `blocks.json` file is saved.
+   */
   public compile(rePath: string) {
-    const entries = Object.keys(this.data).length - 1;
+    const entries = Object.keys(this.data).length - 1; // Exclude format_version
     if (entries <= 0) return;
     const startTime = Benchmark.set();
     let errors = 0;

--- a/Framework/Classes/Properties/itemMap.ts
+++ b/Framework/Classes/Properties/itemMap.ts
@@ -2,9 +2,10 @@ import * as fs from "fs";
 import { Benchmark, Console } from "../../Utilities/utils";
 
 /**
- * Item map class for generating item texture mappings.
+ * ItemMap class used for generating item texture mappings.
  *
- * Generates as `item_texture.json`
+ * This class generates a JSON file (`item_texture.json`) containing texture mappings for items.
+ * Each item entry is associated with a texture, and the generated JSON is saved in the specified resource pack directory.
  */
 export class ItemMap {
   private projectId = "unknown";
@@ -12,7 +13,16 @@ export class ItemMap {
     texture_name: "atlas.items",
     texture_data: {},
   };
-  constructor() {}
+
+  /**
+   * Adds entries to the item texture map.
+   *
+   * This method adds texture mappings for items, where each entry contains the item's name as the key
+   * and the associated texture path as the value. The texture path is automatically prefixed with "textures/"
+   * if not already provided.
+   *
+   * @param entries An object where each key is an item name and each value contains the texture path for that item.
+   */
   public entry(entries: {
     [key: string]: {
       textures: string;
@@ -24,6 +34,16 @@ export class ItemMap {
       this.data.texture_data[e[0]] = e[1];
     }
   }
+
+  /**
+   * Compiles and generates the `item_texture.json` file.
+   *
+   * This method creates the `item_texture.json` file in the specified path. The JSON file includes the texture
+   * mappings for all items added using the `entry` method. The file is saved in the `textures` directory of the
+   * specified resource pack path.
+   *
+   * @param rePath The base path where the resource pack is located, used to determine where the `item_texture.json` file is saved.
+   */
   public compile(rePath: string) {
     const entries = Object.keys(this.data.texture_data).length;
     if (entries <= 0) return;

--- a/Framework/Classes/Properties/language.ts
+++ b/Framework/Classes/Properties/language.ts
@@ -6,20 +6,22 @@ import { LanguageKey } from "../../Types/types";
 /**
  * Translation class used for generating text translations.
  *
- * Generates multiple `xx_XX.lang` files based on specified translations.
+ * This class helps in creating language files for multiple translations.
+ * It generates `.lang` files for each language, which includes the translations for specific keys.
+ * The translations can be automatically generated for supported languages if required.
  * 
- * ### Example
+ * @example
  * ```ts
  * project.language.translate({
-  entries: [
-    {
-      key: "accessibility.chat.howtoopen",
-      text: "Press T to tell us you like Cookies!",
-      overrideTranslation: [{ source: "en_GB", text: "Press T to tell us you like Biscuits!" }],
-    },
-  ],
-});
-```
+ *    entries: [
+ *      {
+ *        key: "accessibility.chat.howtoopen",
+ *        text: "Press T to tell us you like Cookies!",
+ *        overrideTranslation: [{ source: "en_GB", text: "Press T to tell us you like Biscuits!" }],
+ *      },
+ *    ],
+ * });
+ * ```
  */
 export class Language {
   private projectId: string = "unknown";
@@ -38,12 +40,27 @@ export class Language {
     }[];
   }[] = [];
   private languages: LanguageKey[] = defaultLanguages;
+
+  /**
+   * Configures the language settings, including whitelisting and blacklisting languages.
+   *
+   * @param options Configuration options for language whitelisting or blacklisting.
+   * - `whitelistAsBlacklist`: If `true`, languages not listed in `whitelistLanguages` will be excluded.
+   * - `whitelistLanguages`: List of languages that should be included. 
+   */
   constructor(options?: {
     whitelistAsBlacklist?: boolean;
     whitelistLanguages?: LanguageKey[];
   }) {
     this.configure(options);
   }
+
+  /**
+   * Configures the language settings based on provided options.
+   * Allows specifying languages to be whitelisted or blacklisted.
+   *
+   * @param options Configuration options for language whitelisting or blacklisting.
+   */
   public async configure(options?: {
     whitelistAsBlacklist?: boolean;
     whitelistLanguages?: LanguageKey[];
@@ -66,10 +83,23 @@ export class Language {
       this.languages = languages;
     }
   }
+
+  /**
+   * Enables automatic translation for languages not listed in the source language.
+   * 
+   * @returns The current instance of the Language class.
+   */
   public autoTranslate() {
     this.automaticTranslation = true;
     return this;
   }
+
+  /**
+   * Adds translations to the translation queue.
+   * 
+   * @param translations Array of translation objects.
+   * Each object contains language-specific entries for keys and their respective translations.
+   */
   public translate(
     ...translations: {
       source?: LanguageKey;
@@ -87,6 +117,11 @@ export class Language {
   ) {
     this.rawInput = this.rawInput.concat(translations);
   }
+
+  /**
+   * Compiles all translations and writes them to `.lang` files for each supported language.
+   * If there is an error during compilation, it logs the number of errors and the time taken.
+   */
   public async compile() {
     if (!this.projectId || this.projectId == "unknown") {
       Console.queue.custom(
@@ -172,8 +207,16 @@ export class Language {
       );
     }
   }
+
+  /**
+   * Translates the provided text to the target language.
+   * 
+   * @param text The text to be translated.
+   * @param target The target language for the translation.
+   * @returns The translated text.
+   */
   private async feed(text: string, target: string) {
-    return await translate(text, target).catch((e) => {
+    return await translate(text, target).catch((e: Error) => {
       Console.log("Unsupported language: " + e);
     });
   }

--- a/Framework/Classes/Properties/manifest.ts
+++ b/Framework/Classes/Properties/manifest.ts
@@ -3,6 +3,12 @@ import { v4 as uuid } from "uuid";
 import { API_VERSION, MIN_ENGINE_VERSION, MODULE_VERSION } from "../../version";
 import { Benchmark, Console } from "../../Utilities/utils";
 
+/**
+ * Merges two manifest objects, preserving UUIDs from the first manifest.
+ * @param mn1 The first manifest object to merge.
+ * @param mn2 The second manifest object to merge, whose properties will be overridden by mn1 where applicable.
+ * @returns The merged manifest object.
+ */
 function mergePreserveUuids(mn1: any, mn2: any) {
   for (const key in mn2) {
     if (mn2.hasOwnProperty(key)) {
@@ -23,14 +29,15 @@ type Dependency = {
 };
 
 /**
- * Manifest class used to create a pack manifest.
+ * Manifest class used to create and manage the manifest of a Minecraft resource or behavior pack.
+ * This class provides methods to define metadata, dependencies, modules, and to compile the manifest into JSON.
  * @param options Options for constructing a manifest.
- * ### Example
+ * @example
  * ```ts
  * project.manifest = new Manifest({
  *    header: { name: "Peanut Example", description: "Example pack" },
  * });
- ```
+ * ```
  */
 export class Manifest {
   private data: any = {
@@ -49,6 +56,15 @@ export class Manifest {
       },
     },
   };
+
+  /**
+   * Constructs the Manifest object and initializes the properties with the provided options.
+   * @param options Configuration options for the manifest.
+   * - header: Defines the pack's name, description, version, and other metadata.
+   * - modules: Defines the script entry point and other modules for the pack.
+   * - dependencies: Defines the dependencies of the pack (such as server modules).
+   * - metadata: Additional metadata like authors, license, and URL.
+   */
   constructor(options?: {
     header?: {
       description?: string;
@@ -80,6 +96,12 @@ export class Manifest {
   }) {
     this.properties(options);
   }
+
+  /**
+   * Sets the properties for the manifest object using the provided options.
+   * This method updates the header, modules, dependencies, and metadata of the manifest.
+   * @param options Configuration options to set the properties.
+   */
   public properties(options?: {
     header?: {
       description?: string;
@@ -153,6 +175,7 @@ export class Manifest {
     this.data.metadata.authors = options?.metadata?.authors;
     this.data.metadata.license = options?.metadata?.license;
     this.data.metadata.url = options?.metadata?.url;
+
     // Resource Manifest
     this.resources.header = {
       description:
@@ -175,8 +198,13 @@ export class Manifest {
     this.resources.metadata.license = options?.metadata?.license;
     this.resources.metadata.url = options?.metadata?.url;
   }
+
   /**
-   * Compiles a finished manifest class to JSON. Use after all other methods on this instance to generate it.
+   * Compiles the manifest into JSON format and writes it to the specified file paths.
+   * The method generates two separate manifest files, one for resources and one for behaviors.
+   * @param rePath Path where the resource manifest should be saved.
+   * @param bePath Path where the behavior manifest should be saved.
+   * @param oldManifest Optionally provide old manifest data to merge with the new manifest.
    */
   public compile(rePath: string, bePath: string, oldManifest?: any) {
     const startTime = Benchmark.set();

--- a/Framework/Classes/Properties/terrainMap.ts
+++ b/Framework/Classes/Properties/terrainMap.ts
@@ -2,22 +2,39 @@ import * as fs from "fs";
 import { Benchmark, Console } from "../../Utilities/utils";
 
 /**
- * Terrain map class used for generating text translations.
- * @param identifier The string that is used in-game to identify the block.
- * ### Example
- * ```ts
- * new Block("peanut:example", "Example Block")
- * ```
+ * Terrain map class used for generating texture translations for terrain.
+ * This class allows the addition of texture entries and the compilation of a `terrain_texture.json` file.
+ * @class
  */
 export class TerrainMap {
+  /** The project ID associated with the terrain map. */
   private projectId = "unknown";
+
+  /** The data object containing texture-related information for terrain. */
   private data: any = {
     texture_name: "atlas.terrain",
     padding: 8,
     num_mip_levels: 4,
     texture_data: {},
   };
+
+  /**
+   * Constructs an instance of the TerrainMap class.
+   */
   constructor() {}
+
+  /**
+   * Adds texture entries to the terrain map. If the texture path does not start with "textures/", it will be prefixed with "textures/".
+   * @param entries An object containing texture entries where the key is a block identifier and the value contains texture information.
+   * @example
+   * ```ts
+   * terrainMap.entry({
+   *   "peanut:example": {
+   *     textures: "example_texture"
+   *   }
+   * });
+   * ```
+   */
   public entry(entries: {
     [key: string]: {
       textures:
@@ -45,7 +62,14 @@ export class TerrainMap {
       this.data.texture_data[e[0]] = e[1];
     }
   }
-  public compile(rePath: string) {
+
+  /**
+   * Compiles the terrain map into a `terrain_texture.json` file in the specified resource path.
+   * The resulting JSON file will contain the texture data for terrain entries added to the map.
+   * @param rePath The path where the compiled `terrain_texture.json` file should be saved.
+   * @returns {void}
+   */
+  public compile(rePath: string): void {
     const entries = Object.keys(this.data.texture_data).length;
     if (entries <= 0) return;
     const startTime = Benchmark.set();

--- a/Framework/Classes/project.ts
+++ b/Framework/Classes/project.ts
@@ -2,60 +2,108 @@ import * as fs from "fs";
 import { Manifest, Language, TerrainMap, BlockMap, ItemMap } from "./classes";
 import { Benchmark, Console } from "../Utilities/utils";
 
+/**
+ * Represents a project that handles the compilation and management of resource and behavior packs for Minecraft.
+ */
 export class Project {
+  /** The unique identifier for the project. */
   private id: string;
+
+  /** Path to the resource pack directory. */
   private redir: string;
+
+  /** Path to the behavior pack directory. */
   private bedir: string;
+
+  /** Stores the existing manifests from previous compilations for resource and behavior packs. */
   private oldManifest: { re?: any; be?: any } = {};
+
+  /** The manifest configuration for the project. */
   public manifest: Manifest;
+
+  /** The language configuration for the project. */
   public language: Language;
+
+  /** The terrain map configuration for the project. */
   public terrainMap: TerrainMap;
+
+  /** The block map configuration for the project. */
   public blockMap: BlockMap;
+
+  /** The item map configuration for the project. */
   public itemMap: ItemMap;
+
+  /** Array of additional features or modules associated with the project. */
   public features: any[] = [];
+
+  /**
+   * Initializes a new instance of the Project class.
+   * @param id - The unique identifier for the project.
+   */
   constructor(id: string) {
     this.id = id;
+
     // Initialize project properties.
     this.manifest = new Manifest();
     this.language = new Language();
     this.terrainMap = new TerrainMap();
     this.blockMap = new BlockMap();
     this.itemMap = new ItemMap();
-    // Create ./rp_packs and ./bp_packs folders.
+
+    // Define default directories for resource and behavior packs.
     let redir = "./resource_packs";
     let bedir = "./behavior_packs";
+
+    // Ensure default directories exist.
     if (!fs.existsSync(redir)) fs.mkdirSync(redir);
     if (!fs.existsSync(bedir)) fs.mkdirSync(bedir);
-    // Create or remove target pack folder.
+
+    // Define and manage the project-specific directories.
     redir += `/${id}`;
     bedir += `/${id}`;
     if (!fs.existsSync(redir)) fs.mkdirSync(redir);
     if (!fs.existsSync(bedir)) fs.mkdirSync(bedir);
+
+    // Load or clear existing manifests for resource and behavior packs.
     if (fs.existsSync(redir)) {
       const reManifest = redir + "/manifest.json";
-      if (fs.existsSync(reManifest))
+      if (fs.existsSync(reManifest)) {
         this.oldManifest.re = JSON.parse(fs.readFileSync(reManifest, "utf-8"));
+      }
       fs.rmdirSync(redir, { recursive: true });
     }
     fs.mkdirSync(redir);
+
     if (fs.existsSync(bedir)) {
       const beManifest = bedir + "/manifest.json";
-      if (fs.existsSync(beManifest))
+      if (fs.existsSync(beManifest)) {
         this.oldManifest.be = JSON.parse(fs.readFileSync(beManifest, "utf-8"));
+      }
       fs.rmdirSync(bedir, { recursive: true });
     }
     fs.mkdirSync(bedir);
+
     this.redir = redir;
     this.bedir = bedir;
   }
-  public async compile() {
+
+  /**
+   * Compiles the project, including all resource and behavior packs and associated features.
+   */
+  public async compile(): Promise<void> {
     const startTime = Benchmark.set();
     Console.queue.custom(`§5Compiling §r'§9${this.id}§r'...`, 0);
+
+    // Compile the manifest.
     await this.manifest.compile(this.redir, this.bedir, this.oldManifest);
+
+    // Compile additional features.
     for (let feature of this.features) {
       if ("projectId" in feature) feature.projectId = this.id;
       if ("compile" in feature) await feature.compile(this);
     }
+
+    // Compile other configurations.
     (this.language as any).projectId = this.id;
     await this.language.compile();
     (this.blockMap as any).projectId = this.id;
@@ -64,18 +112,29 @@ export class Project {
     await this.terrainMap.compile(this.redir);
     (this.itemMap as any).projectId = this.id;
     await this.itemMap.compile(this.redir);
+
+    // Copy additional resources.
     const resrc = `./${this.id}/resources`;
     const redest = this.redir;
     if (fs.existsSync(resrc)) await this.copyFolderSync(resrc, redest);
+
+    // Complete compilation and log the elapsed time.
     const endTime = Benchmark.set();
     const elapsed = Benchmark.elapsed(startTime, endTime);
     Console.queue.custom("§l§5Compilation completed§r", 5, elapsed);
     Console.writeQueue();
   }
-  private async copyFolderSync(resrc: string, redest: string) {
+
+  /**
+   * Recursively copies the contents of one folder to another.
+   * @param resrc - The source folder path.
+   * @param redest - The destination folder path.
+   */
+  private async copyFolderSync(resrc: string, redest: string): Promise<void> {
     if (!fs.existsSync(redest)) {
       await fs.mkdirSync(redest, { recursive: true });
     }
+
     const files = await fs.readdirSync(resrc);
     for (const file of files) {
       const sourcePath = `${resrc}/${file}`;

--- a/Framework/Types/Minecraft/Block/blockStates.ts
+++ b/Framework/Types/Minecraft/Block/blockStates.ts
@@ -1,3 +1,13 @@
+/**
+ * Represents the various states or properties that a block can have in Minecraft.
+ * These states affect the appearance, behavior, and functionality of the blocks in-game.
+ * 
+ * Each value represents a different aspect of a block that can be tracked or manipulated.
+ * For example, a block might have a "facing_direction" state that determines which direction
+ * it is facing, or a "waterlogged" state that indicates if the block is submerged in water.
+ * 
+ * These block states can be used when manipulating blocks via scripting or defining custom behaviors.
+ */
 export type VanillaBlockState =
   | "active"
   | "age"

--- a/Framework/Types/Minecraft/Block/sides.ts
+++ b/Framework/Types/Minecraft/Block/sides.ts
@@ -1,3 +1,20 @@
+/**
+ * Represents the different sides or directions of a block in Minecraft.
+ * These values are used to identify the relative sides of a block when performing actions
+ * such as block placement, breaking, or redstone interactions.
+ * 
+ * - "up" refers to the top side of a block.
+ * - "down" refers to the bottom side of a block.
+ * - "north" refers to the northern side of a block.
+ * - "south" refers to the southern side of a block.
+ * - "east" refers to the eastern side of a block.
+ * - "west" refers to the western side of a block.
+ * - "side" refers to any of the four horizontal sides (north, south, east, west).
+ * - "all" refers to all sides of the block.
+ * 
+ * These keys are commonly used in scripting when defining interactions or behaviors
+ * based on the orientation of the block.
+ */
 export type BlockSideKey =
   | "up"
   | "down"

--- a/Framework/Types/Minecraft/Block/tags.ts
+++ b/Framework/Types/Minecraft/Block/tags.ts
@@ -1,3 +1,15 @@
+/**
+ * Represents various tags that categorize blocks in Minecraft.
+ * These tags are used to group blocks by their material, function, or properties,
+ * allowing for more efficient block handling, interactions, and behaviors.
+ * Some tags are built-in Minecraft tags, while others are specific to Minecraft scripting.
+ * 
+ * Tags like "minecraft:iron_tier_destructible" or "minecraft:is_pickaxe_item_destructible" 
+ * represent blocks that can be interacted with using specific tool tiers or items.
+ * Tags like "dirt", "grass", "sand", and "stone" categorize blocks by their material type.
+ * Tags such as "mob_spawner" or "plant" describe blocks with special properties or functions.
+ *
+ **/
 export type VanillaBlockTag =
   | "acacia"
   | "birch"

--- a/Framework/Types/Minecraft/Block/traits.ts
+++ b/Framework/Types/Minecraft/Block/traits.ts
@@ -1,3 +1,12 @@
+/**
+ * Represents the traits that can be associated with blocks in Minecraft, specifically related to their placement.
+ * These traits define how a block can be placed in the world, such as its facing direction or position, 
+ * and provide options for adjusting its orientation or rotation during placement.
+ * 
+ * The `minecraft:placement_direction` trait determines which directions the block can face and
+ * optionally allows for a rotational offset.
+ * The `minecraft:placement_position` trait specifies the possible positions where the block can be placed.
+ */
 export type VanillaBlockTraits = {
   "minecraft:placement_direction"?: {
     enabled_states: (

--- a/Framework/Types/Minecraft/Definitions/menuCategory.ts
+++ b/Framework/Types/Minecraft/Definitions/menuCategory.ts
@@ -1,3 +1,8 @@
+/**
+ * Represents the categories that can be assigned to menu items in a Minecraft menu system.
+ * These categories group items based on their general use or type, such as construction materials,
+ * equipment, nature-related items, etc.
+ */
 type VanillaMenuCategories =
   | "construction"
   | "equipment"
@@ -5,6 +10,11 @@ type VanillaMenuCategories =
   | "nature"
   | "none";
 
+/**
+ * Represents the specific item groups that can be associated with menu items in a Minecraft menu system.
+ * These groups represent item sets based on their type, such as specific tools, blocks, or food items.
+ * Each item group corresponds to a unique category of items, like axes, banners, or boats.
+ **/
 type VanillaMenuGroups =
   | "itemGroup.name.anvil"
   | "itemGroup.name.arrow"

--- a/Framework/Types/Minecraft/Descriptors/block.ts
+++ b/Framework/Types/Minecraft/Descriptors/block.ts
@@ -1,5 +1,13 @@
 import { VanillaBlockState } from "../../types";
 
+/**
+ * Represents a descriptor for a block in Minecraft, which can either be a simple string
+ * or an object containing detailed information about the block, such as its name, states, and tags.
+ * 
+ * The `states` property allows specifying different block states, where each state is associated with
+ * a value that can be a string, number, or boolean. The `tags` property allows associating the block
+ * with specific tags.
+*/
 export type BlockDescriptor =
   | string
   | {

--- a/Framework/Types/Minecraft/Descriptors/item.ts
+++ b/Framework/Types/Minecraft/Descriptors/item.ts
@@ -1,1 +1,7 @@
+/**
+ * Represents a descriptor for an item, which can either be a simple string or an object 
+ * containing tags associated with the item.
+ * 
+ * The `tags` property allows associating the item with specific tags.
+ */
 export type ItemDescriptor = string | { tags: string };

--- a/Framework/Types/Minecraft/Enchantment/slot.ts
+++ b/Framework/Types/Minecraft/Enchantment/slot.ts
@@ -1,3 +1,27 @@
+/**
+ * Represents the possible slots where enchantments can be applied.
+ * 
+ * The available slots include various armor pieces, tools, and weapons.
+ * 
+ * - `"armor_feet"`: Boots
+ * - `"armor_torso"`: Chestplate
+ * - `"armor_head"`: Helmet
+ * - `"armor_legs"`: Leggings
+ * - `"axe"`: Axe
+ * - `"bow"`: Bow
+ * - `"cosmetic_head"`: Cosmetic head slot (for non-functional items)
+ * - `"crossbow"`: Crossbow
+ * - `"elytra"`: Elytra
+ * - `"fishing_rod"`: Fishing rod
+ * - `"flintsteel"`: Flint and Steel
+ * - `"hoe"`: Hoe
+ * - `"pickaxe"`: Pickaxe
+ * - `"shears"`: Shears
+ * - `"shield"`: Shield
+ * - `"shovel"`: Shovel
+ * - `"sword"`: Sword
+ * - `"all"`: All possible slots
+*/
 export type EnchantmentSlot =
   | "armor_feet"
   | "armor_torso"

--- a/Framework/Types/Minecraft/Item/equipmentSlot.ts
+++ b/Framework/Types/Minecraft/Item/equipmentSlot.ts
@@ -1,3 +1,14 @@
+/**
+ * Represents the possible equipment slots where items can be worn or equipped.
+ * 
+ * The available slots include weapon and armor slots.
+ * 
+ * - `"slot.weapon.offhand"`: Offhand weapon or item slot
+ * - `"slot.armor.head"`: Helmet or head armor slot
+ * - `"slot.armor.chest"`: Chestplate or torso armor slot
+ * - `"slot.armor.legs"`: Leggings or pants armor slot
+ * - `"slot.armor.feet"`: Boots or footwear armor slot
+*/
 export type EquipmentSlot =
   | "slot.weapon.offhand"
   | "slot.armor.head"

--- a/Framework/Types/Minecraft/Item/tags.ts
+++ b/Framework/Types/Minecraft/Item/tags.ts
@@ -1,3 +1,20 @@
+/**
+ * Represents the various item tags that categorize items in the game.
+ * 
+ * These tags group items by their functionality or type. For example, 
+ * certain tags classify items as tools, foods, or materials for crafting.
+ * 
+ * Some examples of tags include:
+ * - `"minecraft:arrow"`: Items that are arrows.
+ * - `"minecraft:banner"`: Items that are banners.
+ * - `"minecraft:boat"`: Items that are boats.
+ * - `"minecraft:coals"`: Coal-related items.
+ * - `"minecraft:diamond_tier"`: Items related to the diamond tier (e.g., diamond tools).
+ * - `"minecraft:is_food"`: Items that are classified as food.
+ * - `"minecraft:planks"`: Wood planks.
+ * - `"minecraft:stone_tier"`: Items related to the stone tier (e.g., stone tools).
+ * - `"minecraft:wool"`: Wool items.
+*/
 export type VanillaItemTag =
   | "minecraft:arrow"
   | "minecraft:banner"

--- a/Framework/Types/Minecraft/Item/useAnimation.ts
+++ b/Framework/Types/Minecraft/Item/useAnimation.ts
@@ -1,3 +1,20 @@
+/**
+ * Represents the various types of animations that can be used in gameplay.
+ * 
+ * These animations are typically associated with specific actions performed by the player.
+ * 
+ * Some examples of animations include:
+ * - `"eat"`: Animation for eating food.
+ * - `"drink"`: Animation for drinking from a bottle.
+ * - `"bow"`: Animation for using a bow.
+ * - `"block"`: Animation for blocking with an item (usually a shield).
+ * - `"camera"`: Animation related to using a camera.
+ * - `"crossbow"`: Animation for using a crossbow.
+ * - `"none"`: No animation, typically used when no action is performed.
+ * - `"brush"`: Animation for brushing an item.
+ * - `"spear"`: Animation for using a spear.
+ * - `"spyglass"`: Animation for using a spyglass.
+*/
 export type UseAnimation =
   | "eat"
   | "drink"

--- a/Framework/Types/Minecraft/Language/key.ts
+++ b/Framework/Types/Minecraft/Language/key.ts
@@ -1,3 +1,12 @@
+/**
+ * Represents the supported language keys for the system.
+ * 
+ * These language keys correspond to specific regional language codes that define the language
+ * and its regional variant for localization purposes.
+ * 
+ * Each key follows the format of a two-letter language code, followed by a two-letter country code, 
+ * separated by an underscore (e.g., `"en_US"` for English (United States)).
+*/
 export type LanguageKey =
   | "id_ID"
   | "da_DK"

--- a/Framework/Types/Minecraft/Materials/block.ts
+++ b/Framework/Types/Minecraft/Materials/block.ts
@@ -1,3 +1,16 @@
+/**
+ * Defines the different rendering methods for blocks in the game.
+ * 
+ * These methods determine how a block is rendered in the world, affecting how its
+ * transparency, blending, and visibility are handled during rendering.
+ * 
+ * 
+ *   - "alpha_test"               // Renders the block with alpha testing for transparency, where blocks with alpha < 1 are considered transparent.
+ *   - "alpha_test_single_sided"  // Renders the block with single-sided alpha testing for transparency, where the transparency is applied only on one side.
+ *   - "blend"                    // Uses blending to render the block, typically for semi-transparent blocks.
+ *   - "double_sided"             // Renders the block as double-sided, meaning both sides are visible, useful for non-solid or decorative blocks.
+ *   - "opaque"                   // Renders the block as opaque, meaning it is fully solid and does not support transparency or blending.
+ */
 export type BlockRenderMethods =
   | "alpha_test"
   | "alpha_test_single_sided"

--- a/Framework/Types/Minecraft/Materials/entity.ts
+++ b/Framework/Types/Minecraft/Materials/entity.ts
@@ -1,3 +1,72 @@
+/**
+ * Defines the various rendering methods available for entities in the game.
+ * 
+ * These methods control how entities are rendered, including their transparency, blending, emissive effects, 
+ * and other special rendering behaviors such as glint, color changes, and custom entity rendering techniques.
+ * 
+ *   - "alpha_test"                       // Renders the entity with alpha testing for transparency, where alpha < 1 is considered transparent.
+ *   - "alpha_test_single_sided"          // Renders the entity with single-sided alpha testing.
+ *   - "blend"                            // Renders the entity with blending for transparency effects.
+ *   - "double_sided"                     // Renders the entity with both sides visible.
+ *   - "opaque"                           // Renders the entity as fully opaque, with no transparency effects.
+ *   - "alpha_block"                      // Renders the entity with block-level alpha testing.
+ *   - "alpha_block_color"                // Renders the entity with block-level alpha testing and color effects.
+ *   - "banner"                           // Renders the entity as a banner.
+ *   - "banner_pole"                      // Renders the entity as a banner pole.
+ *   - "beacon_beam"                      // Renders the entity as a beacon beam.
+ *   - "beacon_beam_transparent"          // Renders the beacon beam with transparency effects.
+ *   - "charged_creeper"                  // Renders a charged creeper with special effects.
+ *   - "conduit_wind"                     // Renders a conduit with wind effects.
+ *   - "entity"                           // Standard entity rendering method.
+ *   - "entity_alphablend"                // Renders the entity with alpha blending for transparency.
+ *   - "entity_alphablend_nocolorentity_static"  // Renders the entity with alpha blending and no color change.
+ *   - "entity_alphatest"                 // Renders the entity with alpha testing.
+ *   - "entity_alphatest_change_color"    // Renders the entity with alpha testing and a color change effect.
+ *   - "entity_alphatest_change_color_glint" // Renders the entity with alpha testing and glint effects on color change.
+ *   - "entity_alphatest_glint"           // Renders the entity with glint effects applied during alpha testing.
+ *   - "entity_alphatest_glint_item"      // Renders the entity with glint effects on items.
+ *   - "entity_alphatest_multicolor_tint" // Renders the entity with multi-color tint during alpha testing.
+ *   - "entity_beam"                      // Renders the entity as a beam.
+ *   - "entity_beam_additive"             // Renders the entity as an additive beam with transparency.
+ *   - "entity_change_color"              // Renders the entity with a color change effect.
+ *   - "entity_change_color_glint"        // Renders the entity with a color change and glint effect.
+ *   - "entity_custom"                    // Renders the entity with a custom rendering method.
+ *   - "entity_dissolve_layer0"           // Renders the entity with a dissolve effect, layer 0.
+ *   - "entity_dissolve_layer1"           // Renders the entity with a dissolve effect, layer 1.
+ *   - "entity_emissive"                  // Renders the entity with emissive lighting effects.
+ *   - "entity_emissive_alpha"            // Renders the entity with emissive lighting and alpha transparency.
+ *   - "entity_emissive_alpha_one_sided"  // Renders the entity with one-sided emissive lighting and alpha transparency.
+ *   - "entity_flat_color_line"           // Renders the entity as a flat color line.
+ *   - "entity_glint"                     // Renders the entity with a glint effect.
+ *   - "entity_lead_base"                 // Renders the entity with a lead rope base.
+ *   - "entity_loyalty_rope"              // Renders the entity with a loyalty rope effect.
+ *   - "entity_multitexture"              // Renders the entity with multiple textures.
+ *   - "entity_multitexture_alpha_test"   // Renders the entity with multiple textures and alpha testing.
+ *   - "entity_multitexture_alpha_test_color_mask" // Renders the entity with multiple textures, alpha testing, and color mask.
+ *   - "entity_multitexture_color_mask"   // Renders the entity with multiple textures and a color mask.
+ *   - "entity_multitexture_masked"       // Renders the entity with multiple textures and a masked rendering effect.
+ *   - "entity_multitexture_multiplicative_blend" // Renders the entity with a multiplicative blend using multiple textures.
+ *   - "entity_nocull"                    // Renders the entity with no back-face culling.
+ *   - "guardian_ghost"                   // Renders a guardian ghost entity with special effects.
+ *   - "item_in_hand"                     // Renders the entity as an item held in the player's hand.
+ *   - "item_in_hand_entity_alphatest"    // Renders the item in the hand with alpha testing.
+ *   - "item_in_hand_entity_alphatest_color" // Renders the item in the hand with alpha testing and color effects.
+ *   - "item_in_hand_glint"               // Renders the item in the hand with a glint effect.
+ *   - "item_in_hand_multicolor_tint"     // Renders the item in the hand with multi-color tint effects.
+ *   - "map"                              // Renders the map entity.
+ *   - "map_decoration"                   // Renders the map entity as a decoration.
+ *   - "map_marker"                       // Renders the map entity as a marker.
+ *   - "moving_block"                     // Renders the entity as a moving block.
+ *   - "moving_block_alpha"               // Renders the moving block entity with alpha transparency.
+ *   - "moving_block_alpha_seasons"       // Renders the moving block with alpha transparency and seasonal effects.
+ *   - "moving_block_alpha_single_side"   // Renders the moving block with alpha transparency on a single side.
+ *   - "moving_block_blend"               // Renders the moving block with blending effects.
+ *   - "moving_block_double_side"         // Renders the moving block with visibility on both sides.
+ *   - "moving_block_seasons"             // Renders the moving block with seasonal effects.
+ *   - "opaque_block"                     // Renders the entity as an opaque block.
+ *   - "opaque_block_color"               // Renders the entity as an opaque block with color effects.
+ *   - "opaque_block_color_uv2"           // Renders the entity as an opaque block with color and UV mapping.
+ */
 export type EntityRenderMethods =
   | "alpha_test"
   | "alpha_test_single_sided"

--- a/Framework/Types/Minecraft/Molang/flowStatements.ts
+++ b/Framework/Types/Minecraft/Molang/flowStatements.ts
@@ -1,3 +1,14 @@
+/**
+ * Defines the available flow control statements used in Molang expressions.
+ * 
+ * These statements allow for controlling the execution flow within Molang logic.
+ * 
+ *   - "loop"       // Represents a loop that iterates over a set of values or executes indefinitely.
+ *   - "for_each"   // Executes a block of code for each element in a collection or array.
+ *   - "break"      // Exits the nearest loop or control structure, stopping further iterations or execution.
+ *   - "continue"   // Skips the remaining code inside the current iteration of a loop and proceeds to the next iteration.
+ *   - "return"     // Exits from a function or expression, returning a value or ending execution at that point.
+ */
 export type MolangFlowStatement =
   | "loop"
   | "for_each"

--- a/Framework/Types/Minecraft/Molang/math.ts
+++ b/Framework/Types/Minecraft/Molang/math.ts
@@ -1,3 +1,37 @@
+/**
+ * Defines the available mathematical functions in Molang expressions.
+ * 
+ * These functions provide a wide range of mathematical operations and utilities, including trigonometric functions,
+ * random number generation, and more.
+ * 
+ *   - "abs"              // Returns the absolute value of a number.
+ *   - "acos"             // Returns the arc cosine (inverse cosine) of a number.
+ *   - "asin"             // Returns the arc sine (inverse sine) of a number.
+ *   - "atan"             // Returns the arc tangent (inverse tangent) of a number.
+ *   - "atan2"            // Returns the arc tangent of the quotient of its arguments, in radians.
+ *   - "ceil"             // Returns the smallest integer greater than or equal to the number.
+ *   - "clamp"            // Restricts a value within a specified range (minimum and maximum).
+ *   - "cos"              // Returns the cosine of an angle (in radians).
+ *   - "die_roll"         // Simulates a die roll, returning a random number between 1 and 6.
+ *   - "die_roll_integer" // Simulates a die roll, returning a random integer between 1 and a specified number.
+ *   - "exp"              // Returns the value of e raised to the power of the given number.
+ *   - "floor"            // Returns the largest integer less than or equal to the number.
+ *   - "hermite_blend"    // Returns the result of a Hermite interpolation between two values.
+ *   - "lerp"             // Performs linear interpolation between two values.
+ *   - "lerp_rotate"      // Performs a linear interpolation of rotation between two angles.
+ *   - "ln"               // Returns the natural logarithm (base e) of a number.
+ *   - "max"              // Returns the largest of the numbers passed.
+ *   - "min"              // Returns the smallest of the numbers passed.
+ *   - "mod"              // Returns the remainder of dividing two numbers (modulus).
+ *   - "pi"               // Returns the value of pi (approximately 3.14159).
+ *   - "pow"              // Returns the result of raising a number to a specified power.
+ *   - "random"           // Returns a random floating-point number between 0 and 1.
+ *   - "random_integer"   // Returns a random integer between two specified numbers.
+ *   - "round"            // Rounds a number to the nearest integer.
+ *   - "sin"              // Returns the sine of an angle (in radians).
+ *   - "sqrt"             // Returns the square root of a number.
+ *   - "trunc"            // Truncates the decimal portion of a number, returning the integer part.
+ */
 export type MolangMathFunction =
   | "abs"
   | "acos"

--- a/Framework/Types/Minecraft/Molang/operators.ts
+++ b/Framework/Types/Minecraft/Molang/operators.ts
@@ -1,3 +1,25 @@
+/**
+ * Defines the available operators in Molang expressions.
+ * 
+ * These operators are used for performing arithmetic, logical, comparison, and other operations
+ * within Molang expressions.
+ * 
+ *   - "*"   // Multiplication operator, used to multiply two values.
+ *   - "/"   // Division operator, used to divide two values.
+ *   - "+"   // Addition operator, used to add two values.
+ *   - "-"   // Subtraction operator, used to subtract one value from another.
+ *   - "!"   // Logical NOT operator, used to negate a boolean value.
+ *   - "||"  // Logical OR operator, used to combine two boolean values.
+ *   - "&&"  // Logical AND operator, used to combine two boolean values.
+ *   - "<"   // Less than operator, used to compare two values.
+ *   - "<="  // Less than or equal to operator, used to compare two values.
+ *   - ">="  // Greater than or equal to operator, used to compare two values.
+ *   - ">"   // Greater than operator, used to compare two values.
+ *   - "=="  // Equality operator, used to check if two values are equal.
+ *   - "!="  // Inequality operator, used to check if two values are not equal.
+ *   - "??"  // Nullish coalescing operator, returns the right-hand operand if the left-hand operand is null or undefined.
+ *   - "->"  // Arrow operator, used in some specific Molang scenarios for function or event declarations.
+ */
 export type MolangOperator =
   | "*"
   | "/"

--- a/Framework/Types/Minecraft/Molang/queries.ts
+++ b/Framework/Types/Minecraft/Molang/queries.ts
@@ -1,3 +1,163 @@
+/**
+ * Defines the available query functions in Molang expressions.
+ * 
+ * These functions are used to retrieve various properties or states of entities, blocks, and other in-game objects.
+ * Each query function corresponds to a specific property or condition that can be evaluated within Molang expressions.
+ * 
+ *   - "above_top_solid"                    // Checks if the entity is above a solid block.
+ *   - "actor_count"                        // Returns the number of actors.
+ *   - "actor_property"                     // Retrieves a specific property of an actor.
+ *   - "age"                                // Returns the age of an entity.
+ *   - "air"                                // Checks the air level of an entity.
+ *   - "all_animations_finished"            // Checks if all animations of an entity are finished.
+ *   - "all_animations_looping"             // Checks if all animations of an entity are looping.
+ *   - "any_animation_finished"             // Checks if any animation of an entity is finished.
+ *   - "any_animation_looping"              // Checks if any animation of an entity is looping.
+ *   - "any_tag"                            // Checks if the entity has any specific tag.
+ *   - "armor_color_slot"                   // Retrieves the color of armor in a specific slot.
+ *   - "armor_material_slot"                // Retrieves the material of armor in a specific slot.
+ *   - "armor_texture_slot"                 // Retrieves the texture of armor in a specific slot.
+ *   - "attack_time"                        // Returns the time since the entity was last attacked.
+ *   - "block_adjacent_to_liquid"           // Checks if the block is adjacent to a liquid block.
+ *   - "block_face"                         // Returns the face of the block.
+ *   - "block_property"                     // Retrieves a specific property of a block.
+ *   - "block_state"                        // Retrieves the state of a block.
+ *   - "body_x_rotation"                    // Returns the X rotation of the entity's body.
+ *   - "body_y_rotation"                    // Returns the Y rotation of the entity's body.
+ *   - "bone_aabb"                          // Retrieves the axis-aligned bounding box of a bone.
+ *   - "bone_origin"                        // Retrieves the origin of a bone.
+ *   - "bone_rotation"                      // Retrieves the rotation of a bone.
+ *   - "camera_distance"                    // Checks the distance from the camera.
+ *   - "camera_position"                    // Retrieves the position of the camera.
+ *   - "can_climb"                          // Checks if the entity can climb.
+ *   - "can_fly"                            // Checks if the entity can fly.
+ *   - "can_power_jump"                     // Checks if the entity can perform a power jump.
+ *   - "can_swim"                           // Checks if the entity can swim.
+ *   - "can_walk"                           // Checks if the entity can walk.
+ *   - "cape_flap_amount"                   // Retrieves the amount of cape flap.
+ *   - "cape_flap_speed"                    // Retrieves the speed of cape flap.
+ *   - "color"                              // Retrieves the color of an entity or object.
+ *   - "current_squish_value"               // Retrieves the current squish value of an entity.
+ *   - "damage_taken"                       // Retrieves the damage taken by an entity.
+ *   - "day"                                // Checks the current day in the world.
+ *   - "death_time"                         // Retrieves the time when an entity died.
+ *   - "destructible_by_mining"             // Checks if a block is destructible by mining.
+ *   - "distance_from_camera"               // Retrieves the distance from the camera to the entity.
+ *   - "distance_travelled"                 // Retrieves the distance travelled by an entity.
+ *   - "effect_emitter_count"               // Returns the number of effect emitters attached to an entity.
+ *   - "effect_particle_count"              // Returns the number of effect particles attached to an entity.
+ *   - "equipment_count"                    // Returns the number of equipment slots used by an entity.
+ *   - "eye_target_position"                // Retrieves the position of the entity's eye target.
+ *   - "fall_distance"                      // Returns the distance an entity has fallen.
+ *   - "first_person_camera_mode"           // Checks if the first-person camera mode is active.
+ *   - "fishing_hook_distance"              // Retrieves the distance of the fishing hook.
+ *   - "fishing_hook_position"              // Retrieves the position of the fishing hook.
+ *   - "flag"                               // Retrieves a specific flag of an entity.
+ *   - "fleece_color"                       // Retrieves the fleece color of an entity.
+ *   - "ground_speed"                       // Retrieves the speed of the entity on the ground.
+ *   - "has_armor_slot"                     // Checks if the entity has an armor slot.
+ *   - "has_cape"                           // Checks if the entity has a cape.
+ *   - "has_collision"                      // Checks if the entity has collision.
+ *   - "has_equipment_slot"                 // Checks if the entity has an equipment slot.
+ *   - "has_rider"                          // Checks if the entity has a rider.
+ *   - "has_target"                         // Checks if the entity has a target.
+ *   - "health"                             // Retrieves the current health of an entity.
+ *   - "hurt_direction"                     // Retrieves the direction the entity was hurt from.
+ *   - "hurt_time"                          // Retrieves the time since the entity was last hurt.
+ *   - "in_caravan"                         // Checks if the entity is in a caravan.
+ *   - "in_love_ticks"                      // Retrieves the number of ticks the entity has been in love.
+ *   - "is_angry"                           // Checks if the entity is angry.
+ *   - "is_attached_to_entity"              // Checks if the entity is attached to another entity.
+ *   - "is_baby"                            // Checks if the entity is a baby.
+ *   - "is_breathing"                       // Checks if the entity is breathing.
+ *   - "is_casting"                         // Checks if the entity is casting.
+ *   - "is_celebrating"                     // Checks if the entity is celebrating.
+ *   - "is_charged"                         // Checks if the entity is charged.
+ *   - "is_chested"                         // Checks if the entity is chested.
+ *   - "is_critical"                        // Checks if the entity is in a critical state.
+ *   - "is_dancing"                         // Checks if the entity is dancing.
+ *   - "is_eating"                          // Checks if the entity is eating.
+ *   - "is_elder"                           // Checks if the entity is an elder.
+ *   - "is_falling"                         // Checks if the entity is falling.
+ *   - "is_glowing"                         // Checks if the entity is glowing.
+ *   - "is_grazing"                         // Checks if the entity is grazing.
+ *   - "is_idling"                          // Checks if the entity is idling.
+ *   - "is_illager_captain"                 // Checks if the entity is an illager captain.
+ *   - "is_in_love"                         // Checks if the entity is in love.
+ *   - "is_in_ui"                           // Checks if the entity is in a UI.
+ *   - "is_in_water"                        // Checks if the entity is in water.
+ *   - "is_interested"                      // Checks if the entity is interested.
+ *   - "is_invisible"                       // Checks if the entity is invisible.
+ *   - "is_laying_down"                     // Checks if the entity is laying down.
+ *   - "is_laying_egg"                      // Checks if the entity is laying an egg.
+ *   - "is_leashed"                         // Checks if the entity is leashed.
+ *   - "is_lingering"                       // Checks if the entity is lingering.
+ *   - "is_moving"                          // Checks if the entity is moving.
+ *   - "is_on_fire"                         // Checks if the entity is on fire.
+ *   - "is_on_ground"                       // Checks if the entity is on the ground.
+ *   - "is_onfire"                          // Checks if the entity is on fire.
+ *   - "is_orphaned"                        // Checks if the entity is orphaned.
+ *   - "is_powered"                         // Checks if the entity is powered.
+ *   - "is_pregnant"                        // Checks if the entity is pregnant.
+ *   - "is_riding"                          // Checks if the entity is riding.
+ *   - "is_roaring"                         // Checks if the entity is roaring.
+ *   - "is_saddled"                         // Checks if the entity is saddled.
+ *   - "is_shaking"                         // Checks if the entity is shaking.
+ *   - "is_sheared"                         // Checks if the entity is sheared.
+ *   - "is_sleeping"                        // Checks if the entity is sleeping.
+ *   - "is_sneaking"                        // Checks if the entity is sneaking.
+ *   - "is_sprinting"                       // Checks if the entity is sprinting.
+ *   - "is_stackable"                       // Checks if the entity is stackable.
+ *   - "is_stalking"                        // Checks if the entity is stalking.
+ *   - "is_standing"                        // Checks if the entity is standing.
+ *   - "is_swimming"                        // Checks if the entity is swimming.
+ *   - "is_tamed"                           // Checks if the entity is tamed.
+ *   - "is_transforming"                    // Checks if the entity is transforming.
+ *   - "item_count"                         // Retrieves the number of items the entity holds.
+ *   - "item_property"                      // Retrieves a property of an item.
+ *   - "last_hit_by_player"                 // Retrieves the last player that hit the entity.
+ *   - "leash_holder_position"              // Retrieves the position of the entity holding the leash.
+ *   - "life_span"                          // Retrieves the life span of an entity.
+ *   - "life_time"                          // Retrieves the life time of an entity.
+ *   - "limb_speed"                         // Retrieves the speed of the entity's limbs.
+ *   - "liquid_depth"                       // Checks the depth of liquid under the entity.
+ *   - "main_hand_item_count"               // Retrieves the number of items in the entity's main hand.
+ *   - "mark_variant"                       // Retrieves the mark variant of the entity.
+ *   - "max_health"                         // Retrieves the maximum health of the entity.
+ *   - "moon_brightness"                    // Retrieves the brightness of the moon.
+ *   - "moon_phase"                         // Retrieves the current moon phase.
+ *   - "movement_direction"                 // Retrieves the movement direction of the entity.
+ *   - "off_hand_item_count"                // Retrieves the number of items in the entity's off-hand.
+ *   - "on_fire"                            // Checks if the entity is on fire.
+ *   - "owner_identifier"                   // Retrieves the identifier of the entity's owner.
+ *   - "player_level"                       // Retrieves the level of the player.
+ *   - "position"                           // Retrieves the position of the entity.
+ *   - "previous_squish_value"              // Retrieves the previous squish value of the entity.
+ *   - "roll"                               // Retrieves the roll of the entity.
+ *   - "runtime_identifier"                 // Retrieves the runtime identifier of the entity.
+ *   - "saddle_material"                    // Retrieves the material of the saddle.
+ *   - "skin_id"                            // Retrieves the skin ID of the entity.
+ *   - "spellcolor"                         // Retrieves the color of the entity's spell.
+ *   - "strength"                           // Retrieves the strength of the entity.
+ *   - "structural_integrity"               // Retrieves the structural integrity of a block or entity.
+ *   - "swim_amount"                        // Retrieves the swim amount of the entity.
+ *   - "target_distance"                    // Retrieves the distance to the entity's target.
+ *   - "target_position"                    // Retrieves the position of the entity's target.
+ *   - "temp"                               // Retrieves a temporary value associated with the entity.
+ *   - "time_of_day"                        // Retrieves the current time of day in the world.
+ *   - "time_since_death"                   // Retrieves the time since the entity's death.
+ *   - "time_since_hurt"                    // Retrieves the time since the entity was last hurt.
+ *   - "total_emitter_count"                // Retrieves the total number of emitters attached to the entity.
+ *   - "total_particle_count"               // Retrieves the total number of particles attached to the entity.
+ *   - "trade_tier"                         // Retrieves the trade tier of an entity.
+ *   - "unhappy_counter"                    // Retrieves the number of unhappy ticks.
+ *   - "variant"                            // Retrieves the variant of the entity.
+ *   - "vertical_speed"                     // Retrieves the vertical speed of the entity.
+ *   - "walk_distance"                      // Retrieves the distance the entity has walked.
+ *   - "wing_flap_position"                 // Retrieves the wing flap position of the entity.
+ *   - "wing_flap_speed"                    // Retrieves the wing flap speed of the entity.
+ *   - "yaw_speed"                          // Retrieves the yaw speed of the entity.
+ */
 export type MolangQueryFunction =
   | "above_top_solid"
   | "actor_count"

--- a/Framework/Types/Minecraft/geometry.ts
+++ b/Framework/Types/Minecraft/geometry.ts
@@ -1,11 +1,32 @@
 /**
- * Geometry is an JSON component that specifies the geometry identifier and bone visibility to use to render this block. This identifier must match an existing geometry identifier in any of the currently loaded resource packs.
- * @param string - Identifier string.
- *
- * *OR*
- *
- * @param identifier - Valid geometry identifier.
- * @param bone_visibility - An optional array of Booleans that define the visibility of individual bones in the geometry file. In order to set up 'bone_visibility' the geometry file name must be entered as an identifier. After the identifier has been specified, bone_visibility can be defined based on the names of the bones in the specified geometry file on a true/false basis.
+ * Geometry is a JSON component that specifies the geometry identifier and bone visibility to use to render this block.
+ * This identifier must match an existing geometry identifier in any of the currently loaded resource packs.
+ * 
+ * The structure can be defined in one of two ways:
+ * 
+ * 1. A simple string representing the geometry identifier.
+ * 2. An object that includes the geometry identifier and optionally specifies bone visibility.
+ * 
+ * @param {string} identifier - The valid geometry identifier.
+ * 
+ * @param {Object} [bone_visibility] - An optional object defining the visibility of individual bones in the geometry file.
+ * The visibility is determined on a true/false basis for each bone name in the geometry file.
+ * - The geometry file name must be specified as the identifier.
+ * - After specifying the identifier, `bone_visibility` can be defined based on the names of the bones in the geometry file.
+ * 
+ * @example
+ * // Example with just the identifier string:
+ * const geometry = "geometry:block/cube_all";
+ * 
+ * @example
+ * // Example with identifier and bone visibility:
+ * const geometry = {
+ *   identifier: "geometry:block/cube_all",
+ *   bone_visibility: {
+ *     "bone1": true,
+ *     "bone2": false
+ *   }
+ * };
  */
 export type Geometry =
   | {

--- a/Framework/Types/Minecraft/material_instances.ts
+++ b/Framework/Types/Minecraft/material_instances.ts
@@ -2,12 +2,37 @@ import { BlockRenderMethods, EntityRenderMethods } from "../types";
 
 type RenderMethods = BlockRenderMethods | EntityRenderMethods;
 type MaterialKey = "*" | "up" | "down" | "north" | "south" | "east" | "west";
+
 /**
- * The Material Instances component contains a map of material instance names/face names to material instance definitions (JSON Objects). The material instance * is required and will be used for any materials that don't have a match.
- * @param texture - Texture name for the material.
- * @param ambient_occlusion - If this material has ambient occlusion applied when lighting, shadows will be created around and underneath the block. Decimal value controls exponent applied to a value after lighting.
- * @param face_dimming - This material should be dimmed by the direction it's facing.
- * @param render_method - The render method to use. Must be one of the options listed in the table below. See this page to understand the relationship between render method and render distance.
+ * The Material Instances component contains a map of material instance names/face names to material instance definitions (JSON Objects).
+ * The material instance "*" is required and will be used for any materials that don't have a match.
+ * 
+ * Each material instance may include the following properties:
+ * - `texture`: Specifies the texture for the material.
+ * - `ambient_occlusion`: If applied, ambient occlusion will be used when lighting is calculated, creating shadows around and underneath the block.
+ * - `face_dimming`: If true, this material should be dimmed based on the direction it's facing.
+ * - `render_method`: Defines the render method to use, which can be one of the available options from `BlockRenderMethods` or `EntityRenderMethods`. The render method controls how the material is rendered and its associated distance in the world.
+ * 
+ * The structure of the `MaterialInstances` type can either use predefined face names as keys (e.g., "up", "down", "north", "south", "east", "west") or an object with custom keys.
+ * 
+ * @param {string} texture - The texture name for the material.
+ * @param {boolean | number} [ambient_occlusion] - If true or a numeric value is provided, ambient occlusion is applied. The numeric value controls the exponent applied to the lighting.
+ * @param {boolean} [face_dimming] - If true, the material will be dimmed depending on the direction it is facing.
+ * @param {RenderMethods} [render_method] - Specifies the render method for the material. This must be one of the available options for either block or entity rendering.
+ * 
+ * @example
+ * // Example with face-based material definitions:
+ * const materialInstances = {
+ *   "*": { texture: "default_texture" },
+ *   "up": { texture: "top_texture", ambient_occlusion: 0.5, render_method: "blend" },
+ *   "north": { texture: "side_texture", face_dimming: true }
+ * };
+ * 
+ * @example
+ * // Example with a custom key-based material definition:
+ * const materialInstances = {
+ *   "custom_face_1": { texture: "custom_texture", ambient_occlusion: true, render_method: "alpha_test" }
+ * };
  */
 export type MaterialInstances =
   | {

--- a/Framework/Utilities/Common/benchmark.ts
+++ b/Framework/Utilities/Common/benchmark.ts
@@ -1,13 +1,48 @@
 const units = ["ms", "μs", "ns"];
 
+/**
+ * The `Benchmark` class provides utility methods for measuring and formatting time in performance benchmarks.
+ * It can be used to record start times, calculate elapsed times, and format the results in human-readable units.
+ */
 export class Benchmark {
-  public static set() {
+  /**
+   * Records the current time (in high-resolution) for benchmarking purposes.
+   * 
+   * @returns {DOMHighResTimeStamp} The current high-resolution time in milliseconds.
+   * 
+   * @example
+   * const startTime = Benchmark.set();
+   */
+  public static set(): DOMHighResTimeStamp {
     return performance.now();
   }
-  public static elapsed(start: DOMHighResTimeStamp, end: DOMHighResTimeStamp) {
+
+  /**
+   * Calculates the time difference (elapsed time) between two timestamps.
+   * 
+   * @param {DOMHighResTimeStamp} start - The start time of the benchmark.
+   * @param {DOMHighResTimeStamp} end - The end time of the benchmark.
+   * @returns {number} The elapsed time in milliseconds.
+   * 
+   * @example
+   * const elapsedTime = Benchmark.elapsed(startTime, performance.now());
+   */
+  public static elapsed(start: DOMHighResTimeStamp, end: DOMHighResTimeStamp): number {
     return end - start;
   }
-  public static format(value: DOMHighResTimeStamp) {
+
+  /**
+   * Formats a time value into a human-readable string with the appropriate time unit (milliseconds, microseconds, or nanoseconds).
+   * The value will be formatted based on its magnitude, and the most appropriate unit will be chosen.
+   * 
+   * @param {DOMHighResTimeStamp} value - The time value to format.
+   * @returns {string} The formatted time value with the appropriate unit.
+   * 
+   * @example
+   * const formattedTime = Benchmark.format(elapsedTime);
+   * console.log(formattedTime); // e.g., "150 ms" or "500 μs"
+   */
+  public static format(value: DOMHighResTimeStamp): string {
     let unitIndex = 0;
     // Find the appropriate unit
     while (value < 1 && unitIndex < units.length - 1) {

--- a/Framework/Utilities/Common/json.ts
+++ b/Framework/Utilities/Common/json.ts
@@ -1,7 +1,23 @@
 import { Vector } from "../../Types/types";
 
+/**
+ * The `toJSON` class contains utility methods for converting objects into JSON-compatible formats.
+ * It provides methods to transform complex objects, such as `Vector`, into simpler representations for serialization.
+ */
 export class toJSON {
-  public static Vector(vector?: Vector) {
+  /**
+   * Converts a `Vector` object into an array of its x, y, and z components, suitable for JSON serialization.
+   * If no vector is provided, it returns `undefined`.
+   * 
+   * @param {Vector} [vector] - The `Vector` object to be converted.
+   * @returns {number[] | undefined} An array of the `Vector` components `[x, y, z]`, or `undefined` if no vector is provided.
+   * 
+   * @example
+   * const vector = { x: 1, y: 2, z: 3 };
+   * const jsonArray = toJSON.Vector(vector);
+   * console.log(jsonArray); // [1, 2, 3]
+   */
+  public static Vector(vector?: Vector): number[] | undefined {
     return vector ? [vector.x, vector.y, vector.z] : undefined;
   }
 }

--- a/Framework/Utilities/Console/colors.ts
+++ b/Framework/Utilities/Console/colors.ts
@@ -1,3 +1,15 @@
+/**
+ * Replaces Minecraft color codes (prefixed with "§") in the given text with their corresponding ANSI escape codes.
+ * This function is used to convert Minecraft-style text formatting into terminal-compatible formatting.
+ * 
+ * @param {string} text - The input text containing Minecraft color codes.
+ * @returns {string} A string where Minecraft color codes have been replaced with ANSI escape sequences.
+ * 
+ * @example
+ * const text = "§1This is dark blue§r and this is normal.";
+ * const result = replaceMinecraftColorCodes(text);
+ * console.log(result); // Output will be in dark blue, then reset to normal
+ */
 export function replaceMinecraftColorCodes(text: string): string {
   const colorMap: { [key: string]: string } = {
     "§0": "30", // Black

--- a/Framework/Utilities/Console/console.ts
+++ b/Framework/Utilities/Console/console.ts
@@ -1,15 +1,34 @@
 import { Benchmark, replaceMinecraftColorCodes } from "../utils";
 
+/**
+ * The Console class provides methods for logging messages to the console with optional color formatting.
+ * It also includes the ability to manage a queue of logs, sorted by priority and time elapsed, 
+ * and output them with additional information like time stamps and elapsed time.
+ */
 export class Console {
+  /**
+   * Stores the log entries in the queue, each with its source, text, elapsed time, and display order.
+   * @private
+   */
   private static logs: {
     source: keyof typeof Console.queue; // Trace, unused.
     text: string; // Text to log.
-    elapsed?: DOMHighResTimeStamp;
+    elapsed?: DOMHighResTimeStamp; // Time elapsed, if available.
     order: number; // Order to display; larger = higher priority.
   }[] = [];
+
+  /**
+   * Logs a message to the console with Minecraft color code formatting.
+   * @param {string} text - The text to log, possibly containing Minecraft color codes.
+   */
   public static log(text: string) {
     console.log(replaceMinecraftColorCodes(text));
   }
+
+  /**
+   * Writes all queued log entries to the console, sorting them by order and displaying them with time stamps.
+   * If elapsed time is provided, it will be formatted and displayed next to the log message.
+   */
   public static writeQueue() {
     console.log();
     this.logs.sort((a, b) => a.order - b.order);
@@ -23,7 +42,17 @@ export class Console {
     }
     console.log();
   }
+
+  /**
+   * A queue of log types with associated methods to add logs of different severities or custom messages.
+   * Includes log types for info, error, warning, and custom messages.
+   */
   public static queue = {
+    /**
+     * Adds an informational log to the queue.
+     * @param {string} data - The informational data to log.
+     * @param {DOMHighResTimeStamp} [elapsed] - Optional elapsed time to display alongside the log.
+     */
     info: (data: string, elapsed?: DOMHighResTimeStamp) => {
       this.logs.push({
         source: "info",
@@ -34,6 +63,12 @@ export class Console {
         order: 1,
       });
     },
+
+    /**
+     * Adds an error log to the queue.
+     * @param {string} data - The error data to log.
+     * @param {DOMHighResTimeStamp} [elapsed] - Optional elapsed time to display alongside the log.
+     */
     err: (data: string, elapsed?: DOMHighResTimeStamp) => {
       this.logs.push({
         source: "err",
@@ -42,6 +77,11 @@ export class Console {
         order: 3,
       });
     },
+
+    /**
+     * Adds a warning log to the queue.
+     * @param {string} data - The warning data to log.
+     */
     warn: (data: string) => {
       this.logs.push({
         source: "warn",
@@ -49,6 +89,13 @@ export class Console {
         order: 2,
       });
     },
+
+    /**
+     * Adds a custom log to the queue with a specified priority order.
+     * @param {string} data - The custom log data to add.
+     * @param {number} order - The priority order for the log (larger value indicates higher priority).
+     * @param {DOMHighResTimeStamp} [elapsed] - Optional elapsed time to display alongside the log.
+     */
     custom: (data: string, order: number, elapsed?: DOMHighResTimeStamp) => {
       this.logs.push({
         source: "custom",

--- a/Framework/Utilities/Minecraft/Language/default.ts
+++ b/Framework/Utilities/Minecraft/Language/default.ts
@@ -1,33 +1,44 @@
 import { LanguageKey } from "../../../Types/types";
 
+/**
+ * An array containing a list of default language keys supported by the system.
+ * Each element represents a locale code corresponding to a specific language and region.
+ * 
+ * @example
+ * "en_GB" - English (Great Britain)
+ * "es_ES" - Spanish (Spain)
+ * "fr_FR" - French (France)
+ * 
+ * @type {LanguageKey[]}
+ */
 export const defaultLanguages: LanguageKey[] = [
-  "id_ID",
-  "da_DK",
-  "de_DE",
-  "en_GB",
-  "en_US",
-  "es_ES",
-  "es_MX",
-  "fr_CA",
-  "fr_FR",
-  "it_IT",
-  "hu_HU",
-  "nl_NL",
-  "nb_NO",
-  "pl_PL",
-  "pt_BR",
-  "pt_PT",
-  "sk_SK",
-  "fi_FI",
-  "sv_SE",
-  "tr_TR",
-  "cs_CZ",
-  "el_GR",
-  "bg_BG",
-  "ru_RU",
-  "uk_UA",
-  "ja_JP",
-  "zh_CN",
-  "zh_TW",
-  "ko_KR",
+  "id_ID", // Indonesian (Indonesia)
+  "da_DK", // Danish (Denmark)
+  "de_DE", // German (Germany)
+  "en_GB", // English (Great Britain)
+  "en_US", // English (United States)
+  "es_ES", // Spanish (Spain)
+  "es_MX", // Spanish (Mexico)
+  "fr_CA", // French (Canada)
+  "fr_FR", // French (France)
+  "it_IT", // Italian (Italy)
+  "hu_HU", // Hungarian (Hungary)
+  "nl_NL", // Dutch (Netherlands)
+  "nb_NO", // Norwegian Bokmål (Norway)
+  "pl_PL", // Polish (Poland)
+  "pt_BR", // Portuguese (Brazil)
+  "pt_PT", // Portuguese (Portugal)
+  "sk_SK", // Slovak (Slovakia)
+  "fi_FI", // Finnish (Finland)
+  "sv_SE", // Swedish (Sweden)
+  "tr_TR", // Turkish (Turkey)
+  "cs_CZ", // Czech (Czech Republic)
+  "el_GR", // Greek (Greece)
+  "bg_BG", // Bulgarian (Bulgaria)
+  "ru_RU", // Russian (Russia)
+  "uk_UA", // Ukrainian (Ukraine)
+  "ja_JP", // Japanese (Japan)
+  "zh_CN", // Chinese (Simplified, China)
+  "zh_TW", // Chinese (Traditional, Taiwan)
+  "ko_KR", // Korean (South Korea)
 ];

--- a/Framework/commands.js
+++ b/Framework/commands.js
@@ -4,6 +4,16 @@ const { spawn } = require("child_process");
 const args = process.argv.slice(2);
 const command = args[0];
 
+/**
+ * Command-line utility for managing project build, deployment, and watch tasks.
+ * Supports commands for building, watching, deploying, and reloading project scripts.
+ * 
+ * @example
+ * peanut build <path to project directory> - Builds the project at the specified path.
+ * peanut watch <path to project directory> - Watches the project directory for changes.
+ * peanut deploy - Deploys the project packs.
+ * peanut reload <path to project directory> - Reloads the project scripts at the specified path.
+ */
 switch (command) {
   case "build":
     if (!args[1]) {
@@ -44,6 +54,12 @@ switch (command) {
     );
 }
 
+/**
+ * Executes a shell command with the provided arguments and logs the output to the console.
+ *
+ * @param {string} command - The command to execute.
+ * @param {string[]} [args=[]] - An array of arguments to pass to the command.
+ */
 function runCommand(command, args = []) {
   spawn(command, args, { stdio: "inherit", shell: true });
 }

--- a/Framework/version.ts
+++ b/Framework/version.ts
@@ -19,13 +19,46 @@
                                                                                 created by palm1
  */
 
+/**
+ * API version of the current module.
+ * @constant {string}
+ */
 const API_VERSION = "0.0.2";
+
+/**
+ * Minimum engine version required by the module.
+ * @constant {number[]}
+ * @example
+ * [1, 21, 50] represents version 1.21.50
+ */
 const MIN_ENGINE_VERSION = [1, 21, 50];
+
+/**
+ * Format versions for different types of assets.
+ * @constant {Object}
+ * @property {string} BLOCK - Block format version.
+ * @property {string} ITEM - Item format version.
+ * @property {string} BLOCKMAP - Blockmap format version.
+ */
 const FORMAT_VERSION = {
   BLOCK: "1.21.50",
   ITEM: "1.21.50",
   BLOCKMAP: "1.21.40",
 };
+
+/**
+ * Version information for various modules.
+ * @constant {Object}
+ * @property {Object} server - Version information for the server module.
+ * @property {Object} "server-ui" - Version information for the server UI module.
+ * @property {Object} "server-net" - Version information for the server network module.
+ * @property {Object} "server-gametest" - Version information for the server gametest module.
+ * @property {Object} "server-editor" - Version information for the server editor module.
+ * @property {Object} "server-admin" - Version information for the server admin module.
+ * @property {Object} "debug-utilities" - Version information for the debug utilities module.
+ * @example
+ * MODULE_VERSION.server.latest - The latest version for the server module.
+ */
 const MODULE_VERSION = {
   server: {
     latest: "1.16.0",

--- a/plugins.js
+++ b/plugins.js
@@ -1,15 +1,24 @@
-const fs = require("fs");
-const path = require("path");
-const peanutJson = require("peanut-framework/package.json");
-const API_VERSION = peanutJson.api_version;
-const FRAMEWORK_VERSION = peanutJson.version;
-const yauzl = require("yauzl");
-
+/**
+ * Console utility class for logging and managing logs in order.
+ */
 class Console {
+  /**
+   * Array that stores queued log objects.
+   * @type {Array<{text: string, order: number}>}
+   */
   static logs = [];
+
+  /**
+   * Logs a message to the console with Minecraft color codes replaced by terminal color codes.
+   * @param {string} text - The message to log.
+   */
   static log(text) {
     console.log(replaceMinecraftColorCodes(text));
   }
+
+  /**
+   * Writes all logs from the queue to the console, sorted by their order.
+   */
   static writeQueue() {
     console.log();
     this.logs.sort((a, b) => a.order - b.order);
@@ -21,7 +30,16 @@ class Console {
     }
     console.log();
   }
+
+  /**
+   * Queue object for adding log messages with a specific order.
+   */
   static queue = {
+    /**
+     * Adds a log entry to the queue.
+     * @param {string} data - The log message to be added.
+     * @param {number} order - The order in which the log should be displayed.
+     */
     log: (data, order) => {
       this.logs.push({
         text: replaceMinecraftColorCodes(data),
@@ -31,6 +49,11 @@ class Console {
   };
 }
 
+/**
+ * Replaces Minecraft color codes with terminal color codes for proper display.
+ * @param {string} text - The text containing Minecraft color codes.
+ * @returns {string} The text with Minecraft color codes replaced by terminal codes.
+ */
 function replaceMinecraftColorCodes(text) {
   const colorMap = {
     "§0": "30", // Black
@@ -66,6 +89,10 @@ function replaceMinecraftColorCodes(text) {
   return result;
 }
 
+/**
+ * Loads plugins from the specified project directory, extracts archives, and validates plugin data.
+ * @param {string} projectDir - The path to the project directory containing plugins.
+ */
 async function loadPlugins(projectDir) {
   try {
     // Check if project directory is valid
@@ -167,6 +194,12 @@ async function loadPlugins(projectDir) {
   Console.writeQueue();
 }
 
+/**
+ * Extracts a plugin archive (zip or pfplugin file) to the plugins directory.
+ * @param {string} filePath - The path to the plugin archive.
+ * @param {string} pluginsDir - The path to the plugins directory where the archive will be extracted.
+ * @returns {Promise<void>} A promise that resolves once extraction is complete.
+ */
 async function extractPluginArchive(filePath, pluginsDir) {
   return new Promise((resolve, reject) => {
     yauzl.open(filePath, { lazyEntries: true }, (err, zipfile) => {
@@ -227,6 +260,12 @@ async function extractPluginArchive(filePath, pluginsDir) {
   });
 }
 
+/**
+ * Copies scripts from the source directory to the destination directory.
+ * @param {string} source - The path to the source directory containing scripts.
+ * @param {string} destination - The path to the destination directory where scripts will be copied.
+ * @returns {Promise<void>} A promise that resolves when the copying is complete.
+ */
 async function copyScripts(source, destination) {
   try {
     await fs.promises.mkdir(destination, { recursive: true });
@@ -249,14 +288,15 @@ async function copyScripts(source, destination) {
   }
 }
 
+/**
+ * Main execution function for loading plugins from a project directory.
+ * @param {string} projectDir - The path to the project directory.
+ */
 const projectDir = process.argv[2];
 
 if (!projectDir) {
   console.error(
-    "\x1b[91mError: \x1b[0mProject path must be passed as an argument.\x1b[0m"
-  );
-  console.error(
-    "\x1b[94mUsage: \x1b[33mpeanut \x1b[0mreload \x1b[91m<path to project directory>\x1b[0m"
+    "\x1b[91mError: No project directory provided. Please specify the directory.\x1b[0m"
   );
   process.exit(1);
 }


### PR DESCRIPTION
- Documented Console class methods, including logging and queue management
- Added JSDoc to replaceMinecraftColorCodes function for Minecraft color code conversion
- Included JSDoc for loadPlugins, extractPluginArchive, and copyScripts functions
- Improved documentation for plugin handling and directory structure validation

Many IDEs (like VSCode) use JSDoc comments to provide helpful autocomplete suggestions and inline documentation.